### PR TITLE
Making Valves optional and tweak to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,3 @@
-# Flow Control
-
-This mod has two main features: specific rotatable pipe sections and valves.
-
 ## Rotatable Pipe Sections
 
 Using these three new pipe sections you can build almost any pipe layout without worrying about unwanted connections. Each pipe is crafted from one normal pipe, and when mined drops a normal pipe.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This mod has two main features: specific rotatable pipe sections and valves.
 
-## Specific Rotatable Pipe Seconds
+## Rotatable Pipe Sections
 
 Using these three new pipe sections you can build almost any pipe layout without worrying about unwanted connections. Each pipe is crafted from one normal pipe, and when mined drops a normal pipe.
 
@@ -10,16 +10,13 @@ Using these three new pipe sections you can build almost any pipe layout without
 - **T-Junction**
 - **Straight**
 
+When construction ghosts or blueprints of these sections are placed, construction bots are able to build them using normal pipes.
+
 ![Imgur](https://i.imgur.com/B50vSJ1.png)
 
 ## Valves
 
-This mod includes three valves from the [Valves](https://mods.factorio.com/mod/valves) mod.
-- **One way valve:** Only allows flow in one direction, when the input fluid level is higher than the output fluid level.
-- **Overflow valve:** Only allows flow in one direction when the input is higher than 80% full.
-- **Top up valve:** Only allows flow in one direction when the output is higher than 50% full.
-
-These thresholds are also customizable with easy shortcuts (`Numpad +/-`) with the defaults configurable in the map settings.
+One-way, overflow and top-up valves have been moved to the  [Valves](https://mods.factorio.com/mod/valves) mod.
 
 ![](https://assets-mod.factorio.com/assets/bafb8826075e9dfb36bdea25709280c86a23f098.png)
 

--- a/info.json
+++ b/info.json
@@ -8,6 +8,6 @@
   "factorio_version": "2.0",
   "dependencies": [
     "base >= 2.0.8",
-    ? "valves >= 1.0.0"
+    "? valves >= 1.0.0"
   ]
 }

--- a/info.json
+++ b/info.json
@@ -8,6 +8,6 @@
   "factorio_version": "2.0",
   "dependencies": [
     "base >= 2.0.8",
-    "valves >= 1.0.0"
+    ? "valves >= 1.0.0"
   ]
 }

--- a/locale/en/locale.cfg
+++ b/locale/en/locale.cfg
@@ -9,4 +9,4 @@ flow-control-revert-to-normal-pipe=Picked up pipes become base pipes
 
 [mod-setting-description]
 flow-control-new-group=Moves pipes, pumps and valves to a new line in the crafting menu.
-flow-control-revert-to-normal-pipe=When picking up T-Junction, elbow or straight pipes, it reverts back to normal pipes.
+flow-control-revert-to-normal-pipe=When picking up T-Junction, elbow or straight pipes, they revert back to normal pipes.


### PR DESCRIPTION
I think the Valves mod should be an optional dependency, to keep it cleaner for people who just want the pipes
Also a tweak to the localisation and added a note to the readme explaining that ghosts can be built by bots using regular pipes